### PR TITLE
Add version to advancedsettings.xml to avoid log warning

### DIFF
--- a/root/defaults/advancedsettings.xml
+++ b/root/defaults/advancedsettings.xml
@@ -1,4 +1,4 @@
-<advancedsettings>
+<advancedsettings version="1.0">
 <!-- 
 #####################################################
 # For more information on the settings available in #


### PR DESCRIPTION
In Matrix, add this version number to avoid the `WARNING <CSettingsManager>: missing version attribute` in the log
https://kodi.wiki/view/Advancedsettings.xml